### PR TITLE
fix the bug in iOS12 and below versions: the page for selecting conta…

### DIFF
--- a/ios/Classes/SwiftFlutterNativeContactPickerPlugin.swift
+++ b/ios/Classes/SwiftFlutterNativeContactPickerPlugin.swift
@@ -26,7 +26,7 @@ var _result: FlutterResult?;
               contactPicker.delegate = self
               contactPicker.displayedPropertyKeys = [CNContactPhoneNumbersKey]
 
-              let viewController = UIApplication.shared.windows.first?.rootViewController
+              let viewController = UIApplication.shared.keyWindow?.rootViewController
               viewController?.present(contactPicker, animated: true, completion: nil)
           }
       }


### PR DESCRIPTION
### Fixed the bug that the previous code could not pop up the iOS native contact selection page in iOS12 and below iOS systems.

----

When the previous code was run on iOS12 and below, the compiler would print the following log:

  Warning: Attempt to present <CNContactPickerViewController: 0x1104510e0> on <UIViewController: 0x103b110a0> whose view is not in the window hierarchy!

At the same time, the iOS native selection contact page cannot be popped up.

----
## This is because multi-window is only supported starting from IOS13.
In iOS12 and below iOS systems, the view controller returned by UIApplication.shared.windows.first?.rootViewController has nothing to do with the current window.