### PR TITLE
Fix iOS compilation warning in IOS13 and above systems: 'keyWindow' was deprecated in iOS 13.0

### DIFF
--- a/ios/Classes/SwiftFlutterNativeContactPickerPlugin.swift
+++ b/ios/Classes/SwiftFlutterNativeContactPickerPlugin.swift
@@ -25,8 +25,19 @@ var _result: FlutterResult?;
               let contactPicker = CNContactPickerViewController()
               contactPicker.delegate = self
               contactPicker.displayedPropertyKeys = [CNContactPhoneNumbersKey]
-
-              let viewController = UIApplication.shared.keyWindow?.rootViewController
+              
+              // find proper keyWindow
+              var keyWindow: UIWindow? = nil
+              if #available(iOS 13, *) {
+                  keyWindow = UIApplication.shared.connectedScenes.filter {
+                      $0.activationState == .foregroundActive
+                  }.compactMap { $0 as? UIWindowScene
+                  }.first?.windows.filter({ $0.isKeyWindow}).first
+              } else {
+                  keyWindow = UIApplication.shared.keyWindow
+              }
+              
+              let viewController = keyWindow?.rootViewController
               viewController?.present(contactPicker, animated: true, completion: nil)
           }
       }

--- a/ios/Classes/SwiftFlutterNativeContactPickerPlugin.swift
+++ b/ios/Classes/SwiftFlutterNativeContactPickerPlugin.swift
@@ -26,7 +26,7 @@ var _result: FlutterResult?;
               contactPicker.delegate = self
               contactPicker.displayedPropertyKeys = [CNContactPhoneNumbersKey]
 
-              let viewController = UIApplication.shared.windows.first?.rootViewController
+              let viewController = UIApplication.shared.keyWindow?.rootViewController
               viewController?.present(contactPicker, animated: true, completion: nil)
           }
       }


### PR DESCRIPTION
Fix iOS compilation warning in IOS13 and above systems:

'keyWindow' was deprecated in iOS 13.0: Should not be used for applications that support multiple scenes as it returns a key window across all connected scenes